### PR TITLE
v0.7.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # StickyHeaders
 Adapter and LayoutManager for Android RecyclerView which enables sticky header positioning.
 
+This repository is a fork of [ShamylZakariya/StickyHeaders](https://github.com/ShamylZakariya/StickyHeaders) with some updates: AndroidX + few bugs fixes. His work really helped our team so we'll try to maintain his work as longer as possible.
+
 ---
 
 ## Download
 minSdkVersion: 11
 ```
-compile 'io.sportner.stickyheaders:stickyheaders:0.7.6'
+compile 'io.sportner.stickyheaders:stickyheaders:0.7.8'
 ```
 
 ---

--- a/stickyheaders/build.gradle
+++ b/stickyheaders/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.jfrog.bintray'
 apply plugin: 'com.github.dcendents.android-maven'
 
 group = 'io.sportner.stickyheaders'
-version = '0.7.7'
+version = '0.7.8'
 
 android {
 	compileSdkVersion 28

--- a/stickyheaders/src/main/java/io/sportner/stickyheaders/SectioningAdapter.java
+++ b/stickyheaders/src/main/java/io/sportner/stickyheaders/SectioningAdapter.java
@@ -861,7 +861,6 @@ public class SectioningAdapter extends RecyclerView.Adapter<SectioningAdapter.Vi
 			buildSectionIndex();
 			notifyAllSectionsDataSetChanged();
 		} else {
-			buildSectionIndex();
 			Section section = this.sections.get(sectionIndex);
 
 			// 0 is a valid position to remove from
@@ -880,6 +879,7 @@ public class SectioningAdapter extends RecyclerView.Adapter<SectioningAdapter.Vi
 			}
 
 			notifyItemRangeRemoved(section.adapterPosition + offset, number);
+			buildSectionIndex();
 		}
 
 		if (updateSelectionState) {


### PR DESCRIPTION
First "official" release since the fork:
 - [Migrate to AndroidX](https://github.com/ShamylZakariya/StickyHeaders/issues/96)
 - [Fix crash when using `notifySectionItemRangeRemoved` on last section item](https://github.com/ShamylZakariya/StickyHeaders/issues/82)
 - Update gradle and all depedencies  
 - Move package to "io.sportner.stickyheaders" 